### PR TITLE
Fix ARM gluegen-rt-natives-linux-"amdv7, amdv5".jar name lookup typo.

### DIFF
--- a/src/java/com/jogamp/common/os/Platform.java
+++ b/src/java/com/jogamp/common/os/Platform.java
@@ -446,16 +446,16 @@ public class Platform {
                 _os_and_arch = "i586";
                 break;
             case ARM:
-                _os_and_arch = "amdv7"; // TODO: sync with gluegen-cpptasks-base.xml
+                _os_and_arch = "armv7"; // TODO: sync with gluegen-cpptasks-base.xml
                 break;
             case ARMv5:
-                _os_and_arch = "amdv5";
+                _os_and_arch = "armv5";
                 break;
             case ARMv6:
-                _os_and_arch = "amdv5";
+                _os_and_arch = "armv5";
                 break;
             case ARMv7:
-                _os_and_arch = "amdv7";
+                _os_and_arch = "armv7";
                 break;
             case SPARC_32:
                 _os_and_arch = "sparc"; 


### PR DESCRIPTION
Found the typo that have bugged me for some time why i had to pass java.library.path to gluegen .so files to get jogamp working on ARM GNU/Linux. 

Signed-off-by: Xerxes Rånby xerxes@zafena.se
