### PR TITLE
JNLP: Cache gluegen-rt-natives for linux-armv6 and linux-armv6hf.

### DIFF
--- a/jnlp-files/gluegen-rt.jnlp
+++ b/jnlp-files/gluegen-rt.jnlp
@@ -53,6 +53,14 @@
     <resources os="Linux" arch="x86_64">
       <nativelib href = "jar/gluegen-rt-natives-linux-amd64.jar" />
     </resources>
+    <resources os="Linux" arch="arm">
+      <nativelib href = "jar/gluegen-rt-natives-linux-armv6.jar" />
+      <nativelib href = "jar/gluegen-rt-natives-linux-armv6hf.jar" />
+    </resources>
+    <resources os="Linux" arch="armv7">
+      <nativelib href = "jar/gluegen-rt-natives-linux-armv6.jar" />
+      <nativelib href = "jar/gluegen-rt-natives-linux-armv6hf.jar" />
+    </resources>
     <resources os="Mac OS X" arch="i386">
       <nativelib href = "jar/gluegen-rt-natives-macosx-universal.jar" />
     </resources>


### PR DESCRIPTION
Due to the lack of OS Arch and ABI detection in JNLP launchers
force us download both armv6 armel and armv6hf armhf ABI jars on ARM.
