### PR TITLE
Allow Ignore in config to ignore unnamed structs.

### DIFF
--- a/src/java/com/jogamp/gluegen/JavaEmitter.java
+++ b/src/java/com/jogamp/gluegen/JavaEmitter.java
@@ -788,6 +788,9 @@ public class JavaEmitter implements GlueEmitter {
     }
 
     if (name == null) {
+        if ((structType.getStructName() != null) && cfg.shouldIgnoreInInterface(structType.getStructName()))
+            return;
+
         LOG.log(WARNING, "skipping emission of unnamed struct \"{0}\"", structType);
         return;
     }


### PR DESCRIPTION
Augments the behavior of the Ignore keyword to
ignore when gluegen skips the emission of unnamed
structs. These structs are usually unnamed because
we've created opaque types for them, so we know
they're not going to be emitted and want to be
able to suppress the warning on a case-by-case
basis.
