### PR TITLE
Fix CStruct annotation processor warning.

### DIFF
--- a/src/java/com/jogamp/gluegen/structgen/CStructAnnotationProcessor.java
+++ b/src/java/com/jogamp/gluegen/structgen/CStructAnnotationProcessor.java
@@ -78,7 +78,7 @@ import jogamp.common.Debug;
  * @author Sven Gothel, et.al.
  */
 @SupportedAnnotationTypes(value = {"com.jogamp.gluegen.structgen.CStruct"})
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
+@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class CStructAnnotationProcessor extends AbstractProcessor {
     private static final String DEFAULT = "_default_";
     private static final boolean DEBUG;


### PR DESCRIPTION
Updated the Java source version the annotation processor supports
to stop it from throwing a warning during the build process.
