### PR TITLE
replace sheband /bin/bash to /bin/sh

### DIFF
--- a/make/scripts/adb-launch-main.sh
+++ b/make/scripts/adb-launch-main.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/sh
 
 export HOST_UID=jogamp
 # jogamp02 - 10.1.0.122

--- a/make/scripts/check-elf.sh
+++ b/make/scripts/check-elf.sh
@@ -1,21 +1,21 @@
-#! /bin/bash
+#!/bin/sh
 
 SDIR=`dirname $0`
 RDIR=$SDIR/../../..
 
-function check_arm_elf_sub() {
+check_arm_elf_sub() {
 
   echo $1
   echo
   readelf -A $1
 }
-function check_arm_elf() {
+check_arm_elf() {
 
   echo "============================================================"
   check_arm_elf_sub $1
   echo "============================================================"
 }
-function check_jogl_arm_elf() {
+check_jogl_arm_elf() {
   echo "============================================================"
   echo JOGL $1
   echo "------------------------------------------------------------"

--- a/make/scripts/check-glibc-build-arm.sh
+++ b/make/scripts/check-glibc-build-arm.sh
@@ -1,10 +1,10 @@
-#! /bin/bash
+#!/bin/sh
 
 SDIR=`dirname $0`
 XDIR=$SDIR/../../make/lib/toolchain
 RDIR=$SDIR/../../..
 
-function check_glibc() {
+check_glibc() {
   OBJDUMP=$1/bin/objdump
 
   echo "------------------------------------------------------------"

--- a/make/scripts/check-glibc.sh
+++ b/make/scripts/check-glibc.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/sh
 
 BDIR=$1
 shift
@@ -6,8 +6,7 @@ shift
 SDIR=`dirname $0`
 RDIR=$SDIR/../../..
 
-function check_glibc() {
-
+check_glibc() {
   echo "------------------------------------------------------------"
   echo $1 via objdump
   echo

--- a/make/scripts/check-java-major-version.sh
+++ b/make/scripts/check-java-major-version.sh
@@ -1,13 +1,13 @@
-#! /bin/bash
+#!/bin/sh
 
 TDIR=`pwd`
 
-function dump_version() {
+dump_version() {
     echo -n "$1: "
     javap -v $1 | grep 'major version'
 }
 
-function dump_versions() {
+dump_versions() {
     cd $1
     #dump_version jogamp.common.Debug
     javap -v `find . -name '*.class'` | grep -e '^Classfile' -e 'major version'
@@ -17,7 +17,7 @@ function dump_versions() {
     cd $TDIR
 }
 
-function do_it() {
+do_it() {
     dump_versions $1/classes
     dump_versions $1/test/build/classes
 }

--- a/make/scripts/check-junit.sh
+++ b/make/scripts/check-junit.sh
@@ -1,9 +1,9 @@
-#! /bin/bash
+#!/bin/sh
 
 builddir=$1
 shift
 
-function checkresult() {
+checkresult() {
     resdir=$1
     shift
     if [ -e $builddir/test/$resdir ] ; then

--- a/make/scripts/crosstest-java-android-armv6-rel.sh
+++ b/make/scripts/crosstest-java-android-armv6-rel.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/sh
 
 export HOST_UID=jogamp
 export HOST_IP=10.1.0.122

--- a/make/scripts/crosstest-junit-android-armv7-rel.sh
+++ b/make/scripts/crosstest-junit-android-armv7-rel.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/sh
 
 export HOST_UID=sven
 export HOST_IP=192.168.0.52

--- a/make/scripts/runtest-secmgr.sh
+++ b/make/scripts/runtest-secmgr.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/sh
 
 TDIR=`pwd`
 SDIR=`dirname $0` #scripts
@@ -71,7 +71,7 @@ echo "grant codeBase \"file:$BDIR/*\" {" > $SPFILE
 echo "   permission java.security.AllPermission;" >> $SPFILE
 echo "};" >> $SPFILE
 
-function onetest() {
+onetest() {
     CLASSPATH=lib/junit.jar:$ANT_JARS:$RDIR/make/lib/TestJarsInJar.jar:$BDIR/gluegen-rt.jar:$BDIR/test/build/gluegen-test.jar
     libspath=$BDIR/test/build/natives
     echo LD_LIBRARY_PATH $LD_LIBRARY_PATH

--- a/make/scripts/runtest.sh
+++ b/make/scripts/runtest.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/sh
 
 builddir="$1"
 shift
@@ -60,7 +60,7 @@ rm -f $LOG
 #D_ARGS="-Djogamp.debug.Bitstream"
 D_ARGS="-Djogamp.debug=all"
 
-function onetest() {
+onetest() {
     #USE_CLASSPATH=lib/junit.jar:$ANT_JARS:lib/semantic-versioning/semver.jar:"$builddir"/../make/lib/TestJarsInJar.jar:"$builddir"/gluegen-rt.jar:"$builddir"/gluegen.jar:"$builddir"/gluegen-test-util.jar:"$builddir"/test/build/gluegen-test.jar
     USE_CLASSPATH=lib/junit.jar:$ANT_JARS:lib/semantic-versioning/semver.jar:"$builddir"/../make/lib/TestJarsInJar.jar:"$builddir"/gluegen-rt.jar:"$builddir"/gluegen.jar:"$builddir"/gluegen-test-util.jar:"$builddir"/test/build/gluegen-test.jar:"$builddir"/gluegen-rt-natives.jar
     #USE_CLASSPATH=lib/junit.jar:$ANT_JARS:lib/semantic-versioning/semver.jar:"$builddir"/../make/lib/TestJarsInJar.jar:"$builddir"/gluegen-rt-alt.jar:"$builddir"/gluegen.jar:"$builddir"/gluegen-test-util.jar:"$builddir"/test/build/gluegen-test.jar

--- a/test/TestMultiAndFatJar/run-fat.sh
+++ b/test/TestMultiAndFatJar/run-fat.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/sh
 
 #D_ARGS="-Djogamp.debug.JNILibLoader -Djogamp.debug.TempFileCache -Djogamp.debug.JarUtil -Djogamp.debug.TempJarCache -Djogamp.debug.IOUtil"
 #D_ARGS="-Djogamp.debug.ProcAddressHelper -Djogamp.debug.NativeLibrary -Djogamp.debug.NativeLibrary.Lookup"

--- a/test/TestMultiAndFatJar/run-multi.sh
+++ b/test/TestMultiAndFatJar/run-multi.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/sh
 
 #D_ARGS="-Djogamp.debug.JNILibLoader -Djogamp.debug.TempFileCache -Djogamp.debug.JarUtil -Djogamp.debug.TempJarCache -Djogamp.debug.IOUtil"
 #D_ARGS="-Djogamp.debug.ProcAddressHelper -Djogamp.debug.NativeLibrary -Djogamp.debug.NativeLibrary.Lookup"

--- a/test/applet/runapplet.sh
+++ b/test/applet/runapplet.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/sh
 
 RDIR=`pwd`
 

--- a/test/native/alignment_test.sh
+++ b/test/native/alignment_test.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/sh
 
 gcc -o alignment_test alignment_test.c
 ./alignment_test


### PR DESCRIPTION
Replace sheband /bin/bash to /bin/sh and fix bashisms (unneeded 'functinon' keywords) in scripts.