### PR TITLE
adding support for android x86 targets

### DIFF
--- a/make/lib/gluegen-cpptasks-android-x86.xml
+++ b/make/lib/gluegen-cpptasks-android-x86.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    This is an example of how to add custom compiler/linker 
+    arguments for a crosscompiler.
+
+    You can use such files with setting the property 'gluegen-cpptasks.file', ie:
+
+        -Dgluegen-cpptasks.file=`pwd`/lib/gluegen-cpptasks-linux-32bit.xml
+
+    In case you want to compile for 32bit on a 64bit machine,
+    you might also need to set the 'os.arch' to 'x86'.
+    Example: gluegen/make/make.gluegen.all.linux-x86.sh
+      -->
+
+<project name="GlueGen-cpptasks-android-x86" basedir="." >
+
+<!-- Set OS and ARCH for crosscompilation compiler configuration -->
+<target name="gluegen.cpptasks.detect.os.custom">
+    <property name="gluegen.cpptasks.detected.os"     value="true" /> 
+    <property name="isUnix"                           value="true" /> 
+    <property name="isAndroid"                        value="true" /> 
+    <property name="isAndroidX86"                     value="true" /> 
+    <property name="jvmDataModel.arg"                 value="-Djnlp.no.jvm.data.model.set=true" /> 
+    <property name="isCrosscompilation"               value="true" />
+    <property name="android.abi"                      value="x86" />
+    <property name="isAbiEabiGnuArmel"                value="true" />
+    <echo message="gluegen.cpptasks.detect.os.custom: GLUEGEN_CPPTASKS_FILE 'gluegen-cpptasks-android-x86' done"/>
+</target>
+
+<import file="${gluegen.root.abs-path}/make/gluegen-cpptasks-base.xml" optional="false" />
+
+<target name="gluegen.cpptasks.configure.compiler" depends="setup.java.home.dir,declare.linux.android">
+    <echo message="Custom forced compiler Android NDK, linker.cfg.android" />
+    <compiler id="compiler.cfg.android" name="gcc">
+      <compilerarg value="--sysroot=${env.TARGET_PLATFORM_ROOT}" />
+      <!-- The default search dirs for 'gcc from $NDK_TOOLCHAIN_ROOT/$TARGET_TRIPLE/bin will not find
+        subprograms properly (see gcc -print-search-dirs). Not sure if this is a bug in the NDK
+        or not. Need to explicitly indicate where subprograms are with -B.
+        NOTE: This is not necessary if using '$TARGET_TRIPLE-gcc' from $NDK_TOOLCHAIN_ROOT/bin. -->
+      <compilerarg value="-B${env.NDK_TOOLCHAIN_ROOT}/libexec/gcc/${env.TARGET_TRIPLE}/${env.GCC_VERSION}" />
+
+      <compilerarg value="-ffunction-sections" />
+      <compilerarg value="-funwind-tables" />
+      <compilerarg value="-fno-stack-protector" />
+      <compilerarg value="-fpic" /> 
+
+      <compilerarg value="-mtune=atom" />
+      <compilerarg value="-mssse3" /> 
+      <compilerarg value="-mfpmath=sse" />
+      <compilerarg value="-mlong-double-80" />
+
+      <compilerarg value="-g" if="c.compiler.use-debug" />
+      <compilerarg value="-O0" if="c.compiler.use-debug" />
+      <compilerarg value="-Os" unless="c.compiler.use-debug" /> 
+      <!--<compilerarg value="-O2" /> -->
+
+      <compilerarg value="-fomit-frame-pointer" /> 
+      <compilerarg value="-fno-strict-aliasing" /> 
+      <compilerarg value="-finline-limit=64" /> 
+      <compilerarg value="-Wa,--noexecstack" /> 
+      <includepath path="${env.NDK_TOOLCHAIN_ROOT}/lib/gcc/${env.TARGET_TRIPLE}/${env.GCC_VERSION}/include" /> <!-- for stdarg.h -->
+      <defineset>
+        <define name="__unix__" />
+        <define name="ANDROID" />
+        <define name="_DEBUG"   if="c.compiler.use-debug"/>        
+        <define name="DEBUG"    if="c.compiler.use-debug"/>        
+        <define name="NDEBUG"   unless="c.compiler.use-debug"/>        
+      </defineset>
+    </compiler>
+
+    <linker id="linker.cfg.android" name="gcc">
+         <linkerarg value="--sysroot=${env.TARGET_PLATFORM_ROOT}" />
+         <linkerarg value="-fpic" /> 
+         <linkerarg value="-fno-use-linker-plugin" /> 
+
+         <linkerarg value="-mtune=atom" />
+         <linkerarg value="-mssse3" />
+         <linkerarg value="-mfpmath=sse" /> 
+
+         <linkerarg value="-nostdlib" />
+         <linkerarg value="-Bdynamic" />
+         <linkerarg value="-Wl,-dynamic-linker,/system/bin/linker" />
+         <linkerarg value="-Wl,-z,nocopyreloc" />
+
+         <linkerarg value="--demangle" /> 
+         <linkerarg value="--gc-sections" /> 
+         <linkerarg value="--no-undefined" /> 
+         <linkerarg value="-static-libgcc"/>
+         <!-- The gcc from $NDK_TOOLCHAIN_ROOT/$TARGET_TRIPLE/bin needs to be told
+           where to find libgcc as the default location (gcc -print-search-dirs)
+           is not correct. Not sure if this is a bug in the NDK or not. We also
+           enforce that libgcc is linked after source files but before other shared
+           libraries. -->
+         <libset dir="${env.NDK_TOOLCHAIN_ROOT}/lib/gcc/${env.TARGET_TRIPLE}/${env.GCC_VERSION}" libs="gcc" />
+         <libset libs="c,m,dl" />
+    </linker>
+
+</target>
+
+<target name="gluegen.cpptasks.declare.compiler" depends="setup.java.home.dir">
+  <echo message="Custom forced Linux.x86 cross compile android" />
+  <property name="compiler.cfg.id.base"          value="compiler.cfg.android" /> 
+  <property name="linker.cfg.id.base"            value="linker.cfg.android" /> 
+  <property name="java.lib.dir.platform"         value="${java.home.dir}/jre/lib/i386" />
+  <property name="java.includes.dir.platform"    value="${java.includes.dir}/linux" />
+</target>
+
+<target name="declare.linux.android">
+      <echo message="android.x86" />
+      <property name="compiler.cfg.id"                      value="compiler.cfg.android" />
+      <property name="linker.cfg.id"                        value="linker.cfg.android" />
+</target>
+
+</project>
+
+

--- a/make/scripts/make.gluegen.all.android-x86-cross.sh
+++ b/make/scripts/make.gluegen.all.android-x86-cross.sh
@@ -1,0 +1,102 @@
+#! /bin/sh
+
+if [ -e $SDIR/setenv-build-jogl-x86_64.sh ] ; then
+    . $SDIR/setenv-build-jogl-x86_64.sh
+fi
+
+export NODE_LABEL=.
+
+export HOST_UID=jogamp
+# jogamp02 - 10.1.0.122
+export HOST_IP=10.1.0.122
+export HOST_RSYNC_ROOT=PROJECTS/JOGL
+
+export TARGET_UID=jogamp
+export TARGET_IP=panda02
+#export TARGET_IP=jautab03
+#export TARGET_IP=jauphone04
+export TARGET_ADB_PORT=5555
+# needs executable bit (probably su)
+export TARGET_ROOT=/data/projects
+export TARGET_ANT_HOME=/usr/share/ant
+
+echo ANDROID_HOME $ANDROID_HOME
+echo NDK_ROOT $NDK_ROOT
+
+if [ -z "$NDK_ROOT" ] ; then
+    #
+    # Generic android-ndk
+    #
+    if [ -e /usr/local/android-ndk ] ; then
+        NDK_ROOT=/usr/local/android-ndk
+    elif [ -e /opt-linux-x86/android-ndk ] ; then
+        NDK_ROOT=/opt-linux-x86/android-ndk
+    elif [ -e /opt/android-ndk ] ; then
+        NDK_ROOT=/opt/android-ndk
+    #
+    # Specific android-ndk-r8d
+    #
+    elif [ -e /usr/local/android-ndk-r8d ] ; then
+        NDK_ROOT=/usr/local/android-ndk-r8d
+    elif [ -e /opt-linux-x86/android-ndk-r8d ] ; then
+        NDK_ROOT=/opt-linux-x86/android-ndk-r8d
+    elif [ -e /opt/android-ndk-r8d ] ; then
+        NDK_ROOT=/opt/android-ndk-r8d
+    else 
+        echo NDK_ROOT is not specified and does not exist in default locations
+        exit 1
+    fi
+elif [ ! -e $NDK_ROOT ] ; then
+    echo NDK_ROOT $NDK_ROOT does not exist
+    exit 1
+fi
+export NDK_ROOT
+
+if [ -z "$ANDROID_HOME" ] ; then
+    if [ -e /usr/local/android-sdk-linux_x86 ] ; then
+        ANDROID_HOME=/usr/local/android-sdk-linux_x86
+    elif [ -e /opt-linux-x86/android-sdk-linux_x86 ] ; then
+        ANDROID_HOME=/opt-linux-x86/android-sdk-linux_x86
+    elif [ -e /opt/android-sdk-linux_x86 ] ; then
+        ANDROID_HOME=/opt/android-sdk-linux_x86
+    else 
+        echo ANDROID_HOME is not specified and does not exist in default locations
+        exit 1
+    fi
+elif [ ! -e $ANDROID_HOME ] ; then
+    echo ANDROID_HOME $ANDROID_HOME does not exist
+    exit 1
+fi
+export ANDROID_HOME
+
+export ANDROID_VERSION=9
+export SOURCE_LEVEL=1.6
+export TARGET_LEVEL=1.6
+export TARGET_RT_JAR=/opt-share/jre1.6.0_30/lib/rt.jar
+
+#export GCC_VERSION=4.4.3
+export GCC_VERSION=4.7
+HOST_ARCH=linux-x86
+export TARGET_TRIPLE=i686-linux-android
+export TOOLCHAIN_NAME=x86
+
+export NDK_TOOLCHAIN_ROOT=$NDK_ROOT/toolchains/${TOOLCHAIN_NAME}-${GCC_VERSION}/prebuilt/${HOST_ARCH}
+export TARGET_PLATFORM_ROOT=${NDK_ROOT}/platforms/android-${ANDROID_VERSION}/arch-x86
+
+# Need to add toolchain bins to the PATH. 
+export PATH="$NDK_TOOLCHAIN_ROOT/$TARGET_TRIPLE/bin:$ANDROID_HOME/platform-tools:$PATH"
+
+export GLUEGEN_CPPTASKS_FILE="lib/gluegen-cpptasks-android-x86.xml"
+
+#export JUNIT_DISABLED="true"
+#export JUNIT_RUN_ARG0="-Dnewt.test.Screen.disableScreenMode"
+
+which gcc 2>&1 | tee make.gluegen.all.android-x86-cross.log
+
+#export JOGAMP_JAR_CODEBASE="Codebase: *.jogamp.org"
+export JOGAMP_JAR_CODEBASE="Codebase: *.goethel.localnet"
+
+#BUILD_ARCHIVE=true \
+ant \
+    -Drootrel.build=build-android-x86 \
+    $* 2>&1 | tee -a make.gluegen.all.android-x86-cross.log

--- a/make/scripts/make.gluegen.all.sh
+++ b/make/scripts/make.gluegen.all.sh
@@ -7,3 +7,4 @@ $SDIR/make.gluegen.all.linux-armv6-cross.sh \
 && $SDIR/make.gluegen.all.linux-x86_64.sh \
 && $SDIR/make.gluegen.all.linux-x86.sh \
 && $SDIR/make.gluegen.all.android-armv6-cross.sh \
+&& $SDIR/make.gluegen.all.android-x86-cross.sh \

--- a/src/java/jogamp/common/os/PlatformPropsImpl.java
+++ b/src/java/jogamp/common/os/PlatformPropsImpl.java
@@ -200,16 +200,10 @@ public abstract class PlatformPropsImpl {
                 }
                 ABI_TYPE = ehAbiType;
             } else {
-                // default
-                if( AndroidVersion.CPU_TYPE.family == CPUFamily.ARM || null == AndroidVersion.CPU_TYPE2 ) {
-                    ARCH = AndroidVersion.CPU_ABI;
-                    CPU_ARCH = AndroidVersion.CPU_TYPE;
-                    ABI_TYPE = AndroidVersion.ABI_TYPE;
-                } else {
-                    ARCH = AndroidVersion.CPU_ABI2;
-                    CPU_ARCH = AndroidVersion.CPU_TYPE2;
-                    ABI_TYPE = AndroidVersion.ABI_TYPE2;
-                }
+                //default
+                ARCH = AndroidVersion.CPU_ABI;
+                CPU_ARCH = AndroidVersion.CPU_TYPE;
+                ABI_TYPE = AndroidVersion.ABI_TYPE;
             }
             ARCH_lower  = ARCH;
         } else {
@@ -502,6 +496,7 @@ public abstract class PlatformPropsImpl {
      *   <li>linux-armv6</li>
      *   <li>linux-armv6hf</li>
      *   <li>android-armv6</li>
+     *   <li>android-x86</li>
      *   <li>macosx-universal</li>
      *   <li>solaris-sparc</li>
      *   <li>solaris-sparcv9</li>


### PR DESCRIPTION
Hi,

In order to add support for Android x86 platforms to gluegen, can you please, as proposed in this pull request:
- add gluegen-cpptasks-android-x86.xml and make.gluegen.all.android-x86-cross.sh configuration and script files
- set -mlong-double-80 to have the same size for long double on android x86 than on X86_32_UNIX platforms, to avoid having to create a new StaticConfig only for this.
- fix PlatformPropsImpl that is forcing the use of CPU_ABI2 when CPU_ABI1 isn't ARM.