### PR TITLE
adding support for android x86 targets - revised

### DIFF
--- a/make/gluegen-cpptasks-base.xml
+++ b/make/gluegen-cpptasks-base.xml
@@ -35,6 +35,7 @@
    -   isAndroidARM64
    -   isAndroidARMv6Armel (set in gluegen.cpptasks.detected.os.2)
    -   isAndroidARMv6Armhf (set in gluegen.cpptasks.detected.os.2)
+   -   isAndroidX86
    -   isLinux
    -   isLinuxAMD64
    -   isLinuxIA64
@@ -339,6 +340,12 @@
         </or>
       </and>
     </condition>
+    <condition property="isAndroidX86">
+      <and>
+        <istrue value="${isAndroid}" />
+        <os arch="x86" />
+      </and>
+    </condition>
     <condition property="isLinuxARMv6">
       <and>
         <istrue value="${isLinux}" />
@@ -588,6 +595,7 @@
     <echo message="AndroidARM64=${isAndroidARM64}" />
     <echo message="AndroidARMv6Armel=${isAndroidARMv6Armel}" />
     <echo message="AndroidARMv6Armhf=${isAndroidARMv6Armhf}" />
+    <echo message="AndroidX86=${isAndroidX86}" />
     <echo message="Linux=${isLinux}" />
     <echo message="LinuxAMD64=${isLinuxAMD64}" />
     <echo message="LinuxIA64=${isLinuxIA64}" />
@@ -707,7 +715,11 @@
     <property name="os.and.arch" value="android-aarch64" />
   </target>
 
-  <target name="gluegen.cpptasks.detect.os.linux" depends="gluegen.cpptasks.detect.os.linux.amd64,gluegen.cpptasks.detect.os.linux.ia64,gluegen.cpptasks.detect.os.linux.x86,gluegen.cpptasks.detect.os.linux.armv6.armel,gluegen.cpptasks.detect.os.linux.armv6.armhf,gluegen.cpptasks.detect.os.android.armv6.armel,gluegen.cpptasks.detect.os.linux.aarch64,gluegen.cpptasks.detect.os.android.armv6.armhf,gluegen.cpptasks.detect.os.android.aarch64,gluegen.cpptasks.detect.os.linux.alpha,gluegen.cpptasks.detect.os.linux.hppa,gluegen.cpptasks.detect.os.linux.mips,gluegen.cpptasks.detect.os.linux.mipsel,gluegen.cpptasks.detect.os.linux.ppc,gluegen.cpptasks.detect.os.linux.s390,gluegen.cpptasks.detect.os.linux.s390x,gluegen.cpptasks.detect.os.linux.sparc" unless="gluegen.cpptasks.detected.os.2" />
+  <target name="gluegen.cpptasks.detect.os.android.x86" unless="gluegen.cpptasks.detected.os.2" if="isAndroidX86">
+    <property name="os.and.arch" value="android-x86" />
+  </target>
+
+  <target name="gluegen.cpptasks.detect.os.linux" depends="gluegen.cpptasks.detect.os.linux.amd64,gluegen.cpptasks.detect.os.linux.ia64,gluegen.cpptasks.detect.os.linux.x86,gluegen.cpptasks.detect.os.linux.armv6.armel,gluegen.cpptasks.detect.os.linux.armv6.armhf,gluegen.cpptasks.detect.os.android.armv6.armel,gluegen.cpptasks.detect.os.linux.aarch64,gluegen.cpptasks.detect.os.android.armv6.armhf,gluegen.cpptasks.detect.os.android.aarch64,gluegen.cpptasks.detect.os.android.x86,gluegen.cpptasks.detect.os.linux.alpha,gluegen.cpptasks.detect.os.linux.hppa,gluegen.cpptasks.detect.os.linux.mips,gluegen.cpptasks.detect.os.linux.mipsel,gluegen.cpptasks.detect.os.linux.ppc,gluegen.cpptasks.detect.os.linux.s390,gluegen.cpptasks.detect.os.linux.s390x,gluegen.cpptasks.detect.os.linux.sparc" unless="gluegen.cpptasks.detected.os.2" />
 
   <target name="gluegen.cpptasks.detect.os.osx" unless="gluegen.cpptasks.detected.os.2" if="isOSX">
     <property name="native.library.suffix"     value="*lib" />

--- a/make/lib/gluegen-cpptasks-android-x86.xml
+++ b/make/lib/gluegen-cpptasks-android-x86.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    This is an example of how to add custom compiler/linker 
+    arguments for a crosscompiler.
+
+    You can use such files with setting the property 'gluegen-cpptasks.file', ie:
+
+        -Dgluegen-cpptasks.file=`pwd`/lib/gluegen-cpptasks-linux-32bit.xml
+
+    In case you want to compile for 32bit on a 64bit machine,
+    you might also need to set the 'os.arch' to 'x86'.
+    Example: gluegen/make/make.gluegen.all.linux-x86.sh
+      -->
+
+<project name="GlueGen-cpptasks-android-x86" basedir="." >
+
+<!-- Set OS and ARCH for crosscompilation compiler configuration -->
+<target name="gluegen.cpptasks.detect.os.custom">
+    <property name="gluegen.cpptasks.detected.os"     value="true" /> 
+    <property name="isUnix"                           value="true" /> 
+    <property name="isAndroid"                        value="true" /> 
+    <property name="isAndroidX86"                     value="true" /> 
+    <property name="jvmDataModel.arg"                 value="-Djnlp.no.jvm.data.model.set=true" /> 
+    <property name="isCrosscompilation"               value="true" />
+    <property name="android.abi"                      value="x86" />
+    <echo message="gluegen.cpptasks.detect.os.custom: GLUEGEN_CPPTASKS_FILE 'gluegen-cpptasks-android-x86' done"/>
+</target>
+
+<import file="${gluegen.root.abs-path}/make/gluegen-cpptasks-base.xml" optional="false" />
+
+<target name="gluegen.cpptasks.configure.compiler" depends="setup.java.home.dir,declare.linux.android">
+    <echo message="Custom forced compiler Android NDK, linker.cfg.android" />
+    <compiler id="compiler.cfg.android" name="gcc">
+      <compilerarg value="--sysroot=${env.TARGET_PLATFORM_ROOT}" />
+      <!-- The default search dirs for 'gcc from $NDK_TOOLCHAIN_ROOT/$TARGET_TRIPLE/bin will not find
+        subprograms properly (see gcc -print-search-dirs). Not sure if this is a bug in the NDK
+        or not. Need to explicitly indicate where subprograms are with -B.
+        NOTE: This is not necessary if using '$TARGET_TRIPLE-gcc' from $NDK_TOOLCHAIN_ROOT/bin. -->
+      <compilerarg value="-B${env.NDK_TOOLCHAIN_ROOT}/libexec/gcc/${env.TARGET_TRIPLE}/${env.GCC_VERSION}" />
+
+      <compilerarg value="-fpic" /> 
+      <!-- compilerarg value="-fPIE" / -->  <!-- not for shared libs, won't produce symbols -->
+      <!-- compilerarg value="-pie" / -->   <!-- not for shared libs, won't produce symbols -->
+      <compilerarg value="-ffunction-sections" />
+      <compilerarg value="-funwind-tables" />
+      <compilerarg value="-fno-stack-protector" />
+      <!-- compilerarg value="-no-canonical-prefixes" / --> <!-- will disallow creating shared library -->
+      <compilerarg value="-Wa,--noexecstack" /> 
+
+      <compilerarg value="-mtune=atom" />
+      <compilerarg value="-mssse3" />
+      <compilerarg value="-mfpmath=sse" />
+      <compilerarg value="-mlong-double-80" />
+
+      <!-- Generic Flags -->
+      <compilerarg value="-O2"                  unless="c.compiler.use-debug" /> 
+      <!-- compilerarg value="-g"                   unless="c.compiler.use-debug" / -->
+      <compilerarg value="-fomit-frame-pointer" unless="c.compiler.use-debug"/> 
+      <compilerarg value="-fno-strict-aliasing"    unless="c.compiler.use-debug"/> 
+      <compilerarg value="-funswitch-loops"     unless="c.compiler.use-debug"/> 
+      <compilerarg value="-finline-limit=300"   unless="c.compiler.use-debug"/> 
+
+      <compilerarg value="-O0"                     if="c.compiler.use-debug" />
+      <compilerarg value="-g"                      if="c.compiler.use-debug" />
+      <compilerarg value="-fno-omit-frame-pointer" if="c.compiler.use-debug" /> 
+      <compilerarg value="-fno-strict-aliasing"    if="c.compiler.use-debug" /> 
+
+      <includepath path="${env.NDK_TOOLCHAIN_ROOT}/lib/gcc/${env.TARGET_TRIPLE}/${env.GCC_VERSION}/include" /> <!-- for stdarg.h -->
+      <defineset>
+        <define name="__unix__" />
+
+        <define name="ANDROID" />
+        <define name="_DEBUG"   if="c.compiler.use-debug"/>        
+        <define name="DEBUG"    if="c.compiler.use-debug"/>        
+        <define name="NDEBUG"   unless="c.compiler.use-debug"/>        
+      </defineset>
+    </compiler>
+
+    <linker id="linker.cfg.android" name="gcc">
+         <linkerarg value="--sysroot=${env.TARGET_PLATFORM_ROOT}" />
+
+         <linkerarg value="-fpic" /> 
+         <!-- linkerarg value="-fPIE" / --> <!-- not for shared libs, won't produce symbols -->
+         <!-- linkerarg value="-pie" / -->  <!-- not for shared libs, won't produce symbols -->
+         <!-- linkerarg value="-no-canonical-prefixes" / --> <!-- will disallow creating shared library -->
+
+         <linkerarg value="-fno-use-linker-plugin" /> 
+
+         <linkerarg value="-mtune=atom" />
+         <linkerarg value="-mssse3" />
+         <linkerarg value="-mfpmath=sse" />
+         <linkerarg value="-mlong-double-80" />
+
+         <linkerarg value="-nostdlib" />
+         <linkerarg value="-Bdynamic" />
+         <linkerarg value="-Wl,-dynamic-linker,/system/bin/linker" />
+         <linkerarg value="-Wl,-z,nocopyreloc" />
+
+         <linkerarg value="--demangle" /> 
+         <linkerarg value="--gc-sections" /> 
+         <linkerarg value="--no-undefined" /> 
+         <linkerarg value="-static-libgcc"/>
+         <!-- The gcc from $NDK_TOOLCHAIN_ROOT/$TARGET_TRIPLE/bin needs to be told
+           where to find libgcc as the default location (gcc -print-search-dirs)
+           is not correct. Not sure if this is a bug in the NDK or not. We also
+           enforce that libgcc is linked after source files but before other shared
+           libraries. -->
+         <libset dir="${env.NDK_TOOLCHAIN_ROOT}/lib/gcc/${env.TARGET_TRIPLE}/${env.GCC_VERSION}" libs="gcc" />
+         <!-- libset libs="c,m,dl,log" / -->
+         <libset libs="c,m,dl" />
+    </linker>
+
+</target>
+
+<target name="gluegen.cpptasks.declare.compiler" depends="setup.java.home.dir">
+  <echo message="Custom forced Linux.x86 cross compile android" />
+  <property name="compiler.cfg.id.base"          value="compiler.cfg.android" /> 
+  <property name="linker.cfg.id.base"            value="linker.cfg.android" /> 
+  <property name="java.lib.dir.platform"         value="${java.home.dir}/jre/lib/i386" />
+  <property name="java.includes.dir.platform"    value="${java.includes.dir}/linux" />
+</target>
+
+<target name="declare.linux.android">
+      <echo message="android.x86" />
+      <property name="compiler.cfg.id"                      value="compiler.cfg.android" />
+      <property name="linker.cfg.id"                        value="linker.cfg.android" />
+</target>
+
+</project>
+
+

--- a/make/scripts/adb-install-all-x86.sh
+++ b/make/scripts/adb-install-all-x86.sh
@@ -1,0 +1,2 @@
+adb $* install ../build-android-x86/jogamp-android-launcher.apk
+adb $* install ../build-android-x86/gluegen-rt-android-x86.apk

--- a/make/scripts/adb-reinstall-all-x86.sh
+++ b/make/scripts/adb-reinstall-all-x86.sh
@@ -1,0 +1,5 @@
+sdir=`dirname $0`
+
+$sdir/adb-uninstall-all.sh $*
+$sdir/adb-install-all-x86.sh $*
+

--- a/make/scripts/make.gluegen.all.android-x86-cross.sh
+++ b/make/scripts/make.gluegen.all.android-x86-cross.sh
@@ -1,0 +1,63 @@
+#! /bin/sh
+
+SDIR=`dirname $0` 
+
+if [ -e $SDIR/setenv-build-jogl-x86_64.sh ] ; then
+    . $SDIR/setenv-build-jogl-x86_64.sh
+fi
+
+if [ -e $SDIR/setenv-android-tools.sh ] ; then
+    . $SDIR/setenv-android-tools.sh
+fi
+
+export NODE_LABEL=.
+
+export HOST_UID=jogamp
+# jogamp02 - 10.1.0.122
+export HOST_IP=10.1.0.122
+export HOST_RSYNC_ROOT=PROJECTS/JOGL
+
+export TARGET_UID=jogamp
+export TARGET_IP=panda02
+#export TARGET_IP=jautab03
+#export TARGET_IP=jauphone04
+export TARGET_ADB_PORT=5555
+# needs executable bit (probably su)
+export TARGET_ROOT=/data/projects
+export TARGET_ANT_HOME=/usr/share/ant
+
+export ANDROID_VERSION=15
+export SOURCE_LEVEL=1.6
+export TARGET_LEVEL=1.6
+export TARGET_RT_JAR=/opt-share/jre1.6.0_30/lib/rt.jar
+
+#export GCC_VERSION=4.4.3
+export GCC_VERSION=4.8
+HOST_ARCH=linux-x86_64
+export TARGET_TRIPLE=i686-linux-android
+export TOOLCHAIN_NAME=x86
+
+export NDK_TOOLCHAIN_ROOT=$NDK_ROOT/toolchains/${TOOLCHAIN_NAME}-${GCC_VERSION}/prebuilt/${HOST_ARCH}
+export TARGET_PLATFORM_ROOT=${NDK_ROOT}/platforms/android-${ANDROID_VERSION}/arch-x86
+
+# Need to add toolchain bins to the PATH. 
+# May need to create symbolic links within $NDK_TOOLCHAIN_ROOT/$TARGET_TRIPLE/bin
+#   cd $NDK_TOOLCHAIN_ROOT/$TARGET_TRIPLE/bin
+#   ln -s ../../bin/i686-linux-android-gcc gcc
+export PATH="$NDK_TOOLCHAIN_ROOT/$TARGET_TRIPLE/bin:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS_VERSION:$PATH"
+
+export GLUEGEN_CPPTASKS_FILE="lib/gluegen-cpptasks-android-x86.xml"
+
+#export JUNIT_DISABLED="true"
+#export JUNIT_RUN_ARG0="-Dnewt.test.Screen.disableScreenMode"
+
+echo PATH $PATH 2>&1 | tee make.gluegen.all.android-x86-cross.log
+echo gcc `which gcc` 2>&1 | tee -a make.gluegen.all.android-x86-cross.log
+
+#export JOGAMP_JAR_CODEBASE="Codebase: *.jogamp.org"
+export JOGAMP_JAR_CODEBASE="Codebase: *.goethel.localnet"
+
+#BUILD_ARCHIVE=true \
+ant \
+    -Drootrel.build=build-android-x86 \
+    $* 2>&1 | tee -a make.gluegen.all.android-x86-cross.log

--- a/make/scripts/make.gluegen.all.sh
+++ b/make/scripts/make.gluegen.all.sh
@@ -7,3 +7,4 @@ $SDIR/make.gluegen.all.linux-armv6-cross.sh \
 && $SDIR/make.gluegen.all.linux-x86_64.sh \
 && $SDIR/make.gluegen.all.linux-x86.sh \
 && $SDIR/make.gluegen.all.android-armv6-cross.sh \
+&& $SDIR/make.gluegen.all.android-x86-cross.sh \

--- a/src/java/jogamp/common/os/PlatformPropsImpl.java
+++ b/src/java/jogamp/common/os/PlatformPropsImpl.java
@@ -269,9 +269,9 @@ public abstract class PlatformPropsImpl {
                 }
                 ABI_TYPE = elfABIType;
             } else {
-                if( AndroidVersion.CPU_TYPE.family == CPUFamily.ARM ||
+                if( AndroidVersion.CPU_TYPE.family == CPUFamily.ARM || AndroidVersion.CPU_TYPE.family == CPUFamily.X86 ||
                     null == AndroidVersion.CPU_TYPE2 ) {
-                    // Favor Android-1: Either b/c ARM Family, or no Android-2
+                    // Favor Android-1: Either b/c ARM or x86 Family, or no Android-2
                     ARCH = AndroidVersion.CPU_ABI;
                     ARCH_lower = ARCH;
                     CPU_ARCH = AndroidVersion.CPU_TYPE;
@@ -505,6 +505,7 @@ public abstract class PlatformPropsImpl {
      * <ul>
      *   <li>android-armv6</li>
      *   <li>android-aarch64</li>
+     *   <li>android-x86</li>
      *   <li>linux-armv6</li>
      *   <li>linux-armv6hf</li>
      *   <li>linux-i586</li>


### PR DESCRIPTION
Hi,

As you've requested, I've revised my previous pull request against the current GlueGen code.

summary:
* added isAndroidX86 property and android-x86 os.and.arch value
* set -mlong-double-80 to have the same size for long double on android x86 than on X86_32_UNIX platforms, to avoid having to create a new StaticConfig only for this.
* fixed PlatformPropsImpl that was forcing the use of CPU_ABI2 when CPU_ABI1 wasn't ARM.

Thanks !