### PR TITLE
doc/manual/index.html www/index.html Fix links.

### DIFF
--- a/doc/manual/index.html
+++ b/doc/manual/index.html
@@ -280,7 +280,7 @@
                         supports binding C and C++ libraries to a variety of scripting
                         languages; <a href="http://www.jniwrapper.com/">JNIWrapper</a>, a
                         commercial tool automating the binding of C APIs to Java; and <a
-                            href="http://www.noodleglue.org/noodleglue/noodleglue.html">NoodleGlue</a>,
+                            href="http://web.archive.org/web/20070419183658/http://www.noodleglue.org/noodleglue/noodleglue.html">NoodleGlue</a>,
                         a recently-released tool automating the binding of C++ APIs to
                         Java. Other language-specific tools such as Perl's XS, Boost.Python
                         and many others exist.
@@ -350,7 +350,7 @@
                     The source code for GlueGen may be obtained by cloning the Git repository:
 
                     <pre>
-    $git clone git://github.com/mbien/gluegen.git gluegen
+    $git clone --recursive git://jogamp.org/srv/scm/gluegen.git gluegen
                     </pre>
 
                     To build GlueGen, cd into the gluegen/make folder and invoke ant.
@@ -450,8 +450,8 @@
 &lt;/gluegen&gt;
                     </pre>
 
-                    Please see the <a href="http://jogl.dev.java.net/">JOGL</a> and <a
-                        href="http://joal.dev.java.net/">JOAL</a> build.xml files for
+                    Please see the <a href="http://jogamp.org/jogl/">JOGL</a> and <a
+                        href="http://jogamp.org/joal/">JOAL</a> build.xml files for
                     concrete, though non-trivial, examples of how to invoke GlueGen via
                     Ant.
 

--- a/www/index.html
+++ b/www/index.html
@@ -53,7 +53,8 @@
 
                     <p>
                         GlueGen is currently used for the projects
-                        <a href="../../jogl/www/">JOGL</a>, <a href="../../jogl/www/">JOCL</a> and
+                        <a href="../../jogl/www/">JOGL</a>,
+                        <a href="../../jocl/www/">JOCL</a> and
                         <a href="../../joal/www/">JOAL</a>.
                     </p>
 


### PR DESCRIPTION
www.noodleglue.org has dissapeared, replaced with archive.org copy
recomend users to checkout gluegen from jogamp scm and recursive include the jcpp submodule
*.dev.java.net -> jogamp.org/*
fix link to jocl

Signed-off-by: Xerxes Rånby <xerxes@gudinna.com>