### PR TITLE
BUG 1166: Fix JavaEmitter JVMUtil_NewDirectByteBufferCopy

### DIFF
--- a/src/java/com/jogamp/gluegen/JavaEmitter.java
+++ b/src/java/com/jogamp/gluegen/JavaEmitter.java
@@ -2501,7 +2501,7 @@ public class JavaEmitter implements GlueEmitter {
     if (getConfig().emitImpl()) {
       cWriter.println("#include <assert.h>");
       cWriter.println();
-      cWriter.println("static jobject JVMUtil_NewDirectByteBufferCopy(JNIEnv *env, void * source_address, jlong capacity); /* forward decl. */");
+      cWriter.println("static jobject JVMUtil_NewDirectByteBufferCopy(JNIEnv *env, void * source_address, jint capacity); /* forward decl. */");
       cWriter.println();
     }
     for (final String code : cfg.customCCode()) {
@@ -2549,7 +2549,7 @@ public class JavaEmitter implements GlueEmitter {
          "    return JNI_TRUE;\n"+
          "}\n"+
          "\n"+
-         "static jobject JVMUtil_NewDirectByteBufferCopy(JNIEnv *env, void * source_address, jlong capacity) {\n"+
+         "static jobject JVMUtil_NewDirectByteBufferCopy(JNIEnv *env, void * source_address, jint capacity) {\n"+
          "    jobject jbyteBuffer;\n"+
          "    void * byteBufferPtr;\n"+
          "\n"+


### PR DESCRIPTION
Prevents jlong to jint truncation
when capacity is passed from jni to java.

com.jogamp.common.nio.Buffers newDirectByteBuffer
and the underlying java.nio.ByteBuffer allocateDirect
only work with capacitys of int size.

Signed-off-by: Xerxes Rånby <xerxes@gudinna.com>