### PR TITLE
Add support for ppc64le architecture.

### DIFF
--- a/make/build.xml
+++ b/make/build.xml
@@ -306,6 +306,18 @@
       <property name="linker.cfg.id"                        value="linker.cfg.linux.ppc" /> 
     </target>
 
+    <target name="declare.linux.ppc64" if="isLinuxPpc64">
+      <echo message="Linux.ppc64" />
+      <property name="compiler.cfg.id"                      value="compiler.cfg.linux" />
+      <property name="linker.cfg.id"                        value="linker.cfg.linux.ppc64" />
+    </target>
+
+    <target name="declare.linux.ppc64le" if="isLinuxPpc64le">
+      <echo message="Linux.ppc64le" />
+      <property name="compiler.cfg.id"                      value="compiler.cfg.linux" />
+      <property name="linker.cfg.id"                        value="linker.cfg.linux.ppc64le" />
+    </target>
+
     <target name="declare.linux.s390" if="isLinuxs390">
       <echo message="Linux.s390" />
       <property name="compiler.cfg.id"                      value="compiler.cfg.linux" /> 
@@ -324,7 +336,7 @@
       <property name="linker.cfg.id"                        value="linker.cfg.linux.sparc" /> 
     </target>
     
-    <target name="declare.linux" depends="declare.linux.x86,declare.linux.amd64,declare.linux.ia64,declare.linux.hppa,declare.linux.mips,declare.linux.mipsel,declare.linux.ppc,declare.linux.s390,declare.linux.s390x,declare.linux.sparc,declare.linux.armv6" if="isLinux" >
+    <target name="declare.linux" depends="declare.linux.x86,declare.linux.amd64,declare.linux.ia64,declare.linux.hppa,declare.linux.mips,declare.linux.mipsel,declare.linux.ppc,declare.linux.ppc64,declare.linux.ppc64le,declare.linux.s390,declare.linux.s390x,declare.linux.sparc,declare.linux.armv6" if="isLinux" >
       <property name="c.src.dir.os"                         value="unix" />
     </target>
 

--- a/make/gluegen-cpptasks-base.xml
+++ b/make/gluegen-cpptasks-base.xml
@@ -48,6 +48,8 @@
    -   isLinuxMips
    -   isLinuxMipsel
    -   isLinuxPpc
+   -   isLinuxPpc64
+   -   isLinuxPpc64le
    -   isLinuxs390
    -   isLinuxs390x
    -   isLinuxSparc
@@ -133,6 +135,8 @@
    -   compiler.cfg.linux.mips
    -   compiler.cfg.linux.mipsel
    -   compiler.cfg.linux.ppc
+   -   compiler.cfg.linux.ppc64
+   -   compiler.cfg.linux.ppc64le
    -   compiler.cfg.linux.s390
    -   compiler.cfg.linux.s390x
    -   compiler.cfg.linux.sparc
@@ -155,6 +159,7 @@
    -   linker.cfg.linux.mips
    -   linker.cfg.linux.mipsel
    -   linker.cfg.linux.ppc
+   -   linker.cfg.linux.ppc64le
    -   linker.cfg.linux.s390
    -   linker.cfg.linux.s390x
    -   linker.cfg.linux.sparc
@@ -417,6 +422,24 @@
     <condition property="ppc">
       <os arch="ppc" />
     </condition>
+    <condition property="isLinuxPpc64">
+      <and>
+        <istrue value="${isLinux}" />
+        <os arch="ppc64" />
+      </and>
+    </condition>
+    <condition property="ppc64">
+      <os arch="ppc64" />
+    </condition>
+    <condition property="isLinuxPpc64le">
+      <and>
+        <istrue value="${isLinux}" />
+        <os arch="ppc64le" />
+      </and>
+    </condition>
+    <condition property="ppc64le">
+      <os arch="ppc64le" />
+    </condition>
     <condition property="isLinuxs390">
       <and>
         <istrue value="${isLinux}" />
@@ -601,6 +624,8 @@
     <echo message="LinuxMips=${isLinuxMips}" />
     <echo message="LinuxMipsel=${isLinuxMipsel}" />
     <echo message="LinuxPpc=${isLinuxPpc}" />
+    <echo message="LinuxPpc64=${isLinuxPpc64}" />
+    <echo message="LinuxPpc64le=${isLinuxPpc64le}" />
     <echo message="Linuxs390=${isLinuxs390}" />
     <echo message="Linuxs390x=${isLinuxs390x}" />
     <echo message="LinuxSparc=${isLinuxSparc}" />
@@ -683,6 +708,14 @@
     <property name="os.and.arch" value="linux-ppc" />
   </target>
 
+  <target name="gluegen.cpptasks.detect.os.linux.ppc64" unless="gluegen.cpptasks.detected.os.2" if="isLinuxPpc64">
+    <property name="os.and.arch" value="linux-ppc64" />
+  </target>
+
+  <target name="gluegen.cpptasks.detect.os.linux.ppc64le" unless="gluegen.cpptasks.detected.os.2" if="isLinuxPpc64le">
+    <property name="os.and.arch" value="linux-ppc64le" />
+  </target>
+
   <target name="gluegen.cpptasks.detect.os.linux.s390" unless="gluegen.cpptasks.detected.os.2" if="isLinuxs390">
     <property name="os.and.arch" value="linux-s390" />
   </target>
@@ -707,7 +740,7 @@
     <property name="os.and.arch" value="android-aarch64" />
   </target>
 
-  <target name="gluegen.cpptasks.detect.os.linux" depends="gluegen.cpptasks.detect.os.linux.amd64,gluegen.cpptasks.detect.os.linux.ia64,gluegen.cpptasks.detect.os.linux.x86,gluegen.cpptasks.detect.os.linux.armv6.armel,gluegen.cpptasks.detect.os.linux.armv6.armhf,gluegen.cpptasks.detect.os.android.armv6.armel,gluegen.cpptasks.detect.os.linux.aarch64,gluegen.cpptasks.detect.os.android.armv6.armhf,gluegen.cpptasks.detect.os.android.aarch64,gluegen.cpptasks.detect.os.linux.alpha,gluegen.cpptasks.detect.os.linux.hppa,gluegen.cpptasks.detect.os.linux.mips,gluegen.cpptasks.detect.os.linux.mipsel,gluegen.cpptasks.detect.os.linux.ppc,gluegen.cpptasks.detect.os.linux.s390,gluegen.cpptasks.detect.os.linux.s390x,gluegen.cpptasks.detect.os.linux.sparc" unless="gluegen.cpptasks.detected.os.2" />
+  <target name="gluegen.cpptasks.detect.os.linux" depends="gluegen.cpptasks.detect.os.linux.amd64,gluegen.cpptasks.detect.os.linux.ia64,gluegen.cpptasks.detect.os.linux.x86,gluegen.cpptasks.detect.os.linux.armv6.armel,gluegen.cpptasks.detect.os.linux.armv6.armhf,gluegen.cpptasks.detect.os.android.armv6.armel,gluegen.cpptasks.detect.os.linux.aarch64,gluegen.cpptasks.detect.os.android.armv6.armhf,gluegen.cpptasks.detect.os.android.aarch64,gluegen.cpptasks.detect.os.linux.alpha,gluegen.cpptasks.detect.os.linux.hppa,gluegen.cpptasks.detect.os.linux.mips,gluegen.cpptasks.detect.os.linux.mipsel,gluegen.cpptasks.detect.os.linux.ppc,gluegen.cpptasks.detect.os.linux.ppc64,gluegen.cpptasks.detect.os.linux.ppc64le,gluegen.cpptasks.detect.os.linux.s390,gluegen.cpptasks.detect.os.linux.s390x,gluegen.cpptasks.detect.os.linux.sparc" unless="gluegen.cpptasks.detected.os.2" />
 
   <target name="gluegen.cpptasks.detect.os.osx" unless="gluegen.cpptasks.detected.os.2" if="isOSX">
     <property name="native.library.suffix"     value="*lib" />
@@ -1268,6 +1301,12 @@
     <linker id="linker.cfg.linux.ppc" name="${gcc.compat.compiler}">
     </linker>
 
+    <linker id="linker.cfg.linux.ppc64" name="${gcc.compat.compiler}">
+    </linker>
+
+    <linker id="linker.cfg.linux.ppc64le" name="${gcc.compat.compiler}">
+    </linker>
+
     <linker id="linker.cfg.linux.s390" name="${gcc.compat.compiler}">
     </linker>
 
@@ -1505,6 +1544,20 @@
       <property name="java.lib.dir.platform"         value="${java.home.dir}/jre/lib/ppc" />
     </target>
 
+    <target name="gluegen.cpptasks.declare.compiler.linux.ppc64" if="isLinuxPpc64">
+      <echo message="Linux.Ppc64" />
+      <property name="compiler.cfg.id.base"          value="compiler.cfg.linux" />
+      <property name="linker.cfg.id.base"            value="linker.cfg.linux" />
+      <property name="java.lib.dir.platform"         value="${java.home.dir}/jre/lib/ppc64" />
+    </target>
+
+    <target name="gluegen.cpptasks.declare.compiler.linux.ppc64le" if="isLinuxPpc64le">
+      <echo message="Linux.Ppc64le" />
+      <property name="compiler.cfg.id.base"          value="compiler.cfg.linux" />
+      <property name="linker.cfg.id.base"            value="linker.cfg.linux" />
+      <property name="java.lib.dir.platform"         value="${java.home.dir}/jre/lib/ppc64le" />
+    </target>
+
     <target name="gluegen.cpptasks.declare.compiler.linux.s390" if="isLinuxs390">
       <echo message="Linux.s390" />
       <property name="compiler.cfg.id.base"          value="compiler.cfg.linux" /> 
@@ -1526,7 +1579,7 @@
       <property name="java.lib.dir.platform"         value="${java.home.dir}/jre/lib/sparc" />
     </target>
 
-    <target name="gluegen.cpptasks.declare.compiler.linux" depends="gluegen.cpptasks.declare.compiler.linux.x86,gluegen.cpptasks.declare.compiler.linux.amd64,gluegen.cpptasks.declare.compiler.linux.ia64,gluegen.cpptasks.declare.compiler.linux.armv6,gluegen.cpptasks.declare.compiler.linux.aarch64,gluegen.cpptasks.declare.compiler.linux.alpha,gluegen.cpptasks.declare.compiler.linux.hppa,gluegen.cpptasks.declare.compiler.linux.mips,gluegen.cpptasks.declare.compiler.linux.mipsel,gluegen.cpptasks.declare.compiler.linux.ppc,gluegen.cpptasks.declare.compiler.linux.s390,gluegen.cpptasks.declare.compiler.linux.s390x,gluegen.cpptasks.declare.compiler.linux.sparc" if="isLinux">
+    <target name="gluegen.cpptasks.declare.compiler.linux" depends="gluegen.cpptasks.declare.compiler.linux.x86,gluegen.cpptasks.declare.compiler.linux.amd64,gluegen.cpptasks.declare.compiler.linux.ia64,gluegen.cpptasks.declare.compiler.linux.armv6,gluegen.cpptasks.declare.compiler.linux.aarch64,gluegen.cpptasks.declare.compiler.linux.alpha,gluegen.cpptasks.declare.compiler.linux.hppa,gluegen.cpptasks.declare.compiler.linux.mips,gluegen.cpptasks.declare.compiler.linux.mipsel,gluegen.cpptasks.declare.compiler.linux.ppc,gluegen.cpptasks.declare.compiler.linux.ppc64,gluegen.cpptasks.declare.compiler.linux.ppc64le,gluegen.cpptasks.declare.compiler.linux.s390,gluegen.cpptasks.declare.compiler.linux.s390x,gluegen.cpptasks.declare.compiler.linux.sparc" if="isLinux">
         <property name="java.includes.dir.platform" value="${java.includes.dir}/x11" />
     </target>
 

--- a/make/scripts/make.gluegen.all.linux-ppc64le.sh
+++ b/make/scripts/make.gluegen.all.linux-ppc64le.sh
@@ -1,0 +1,24 @@
+#! /bin/sh
+
+#    -Dc.compiler.debug=true \
+#    -Dgluegen.cpptasks.detected.os=true \
+#    -DisUnix=true \
+#    -DisLinux=true \
+#    -DisLinuxX86=true \
+#    -DisX11=true \
+
+MACHINE=ppc64le
+ARCH=ppc64el
+TRIPLET=powerpc64le-linux-gnu
+
+export TARGET_PLATFORM_LIBS=/usr/lib/$TRIPLET
+export TARGET_JAVA_LIBS=/usr/lib/jvm/java-7-openjdk-$ARCH/jre/lib/$MACHINE
+
+export GLUEGEN_CPPTASKS_FILE="lib/gluegen-cpptasks-linux-$MACHINE.xml"
+
+#export JOGAMP_JAR_CODEBASE="Codebase: *.jogamp.org"
+export JOGAMP_JAR_CODEBASE="Codebase: *.goethel.localnet"
+
+ant \
+    -Drootrel.build=build-linux-$MACHINE \
+    $* 2>&1 | tee make.gluegen.all.linux-$MACHINE.log

--- a/src/java/com/jogamp/common/os/MachineDataInfo.java
+++ b/src/java/com/jogamp/common/os/MachineDataInfo.java
@@ -63,6 +63,7 @@ public class MachineDataInfo {
   private final static int[] size_sparc_32_sunos  =  { 4,    4,     4,     8,     16,    4,   8192 };
   private final static int[] size_x86_32_windows  =  { 4,    4,     4,     8,     12,    4,   4096 };
   private final static int[] size_lp64_unix       =  { 4,    8,     4,     8,     16,    8,   4096 };
+  private final static int[] size_ppc_64_unix     =  { 4,    8,     4,     8,     16,    8,  65536 };
   private final static int[] size_x86_64_windows  =  { 4,    4,     4,     8,     16,    8,   4096 };
 
   /*                               arch   os          i8, i16, i32, i64, int, long, float, doubl, ldoubl, ptr */
@@ -106,8 +107,10 @@ public class MachineDataInfo {
       SPARC_32_SUNOS( size_sparc_32_sunos, align_sparc_32_sunos),
       /** {@link Platform.CPUType#X86_32} Windows */
       X86_32_WINDOWS( size_x86_32_windows, align_x86_32_windows),
-      /** LP64 Unix, e.g.: {@link Platform.CPUType#X86_64} Unix, {@link Platform.CPUType#ARM64} EABI, {@link Platform.CPUType#PPC64} Unix, .. */
+      /** LP64 Unix, e.g.: {@link Platform.CPUType#X86_64} Unix, {@link Platform.CPUType#ARM64} EABI, .. */
       LP64_UNIX(      size_lp64_unix,    align_lp64_unix),
+      /** {@link Platform.CPUType#PPC64} Unix */
+      PPC_64_UNIX(      size_ppc_64_unix,    align_lp64_unix),
       /** {@link Platform.CPUType#X86_64} Windows */
       X86_64_WINDOWS( size_x86_64_windows, align_x86_64_windows);
       // 8
@@ -332,7 +335,7 @@ public class MachineDataInfo {
              doubleSizeInBytes == md.doubleSizeInBytes &&
              ldoubleSizeInBytes == md.ldoubleSizeInBytes &&
              pointerSizeInBytes == md.pointerSizeInBytes &&
-
+             pageSizeInBytes == md.pageSizeInBytes &&
              int8AlignmentInBytes == md.int8AlignmentInBytes &&
              int16AlignmentInBytes == md.int16AlignmentInBytes &&
              int32AlignmentInBytes == md.int32AlignmentInBytes &&

--- a/src/java/jogamp/common/os/MachineDataInfoRuntime.java
+++ b/src/java/jogamp/common/os/MachineDataInfoRuntime.java
@@ -112,6 +112,8 @@ public class MachineDataInfoRuntime {
       } else {
           if( osType == Platform.OSType.WINDOWS ) {
               return StaticConfig.X86_64_WINDOWS;
+          } else if ( Platform.CPUType.PPC64 == cpuType ) {
+              return StaticConfig.PPC_64_UNIX;
           } else {
               // for all 64bit unix types (x86_64, aarch64, sparcv9, ..)
               return StaticConfig.LP64_UNIX;

--- a/src/java/jogamp/common/os/PlatformPropsImpl.java
+++ b/src/java/jogamp/common/os/PlatformPropsImpl.java
@@ -522,6 +522,7 @@ public abstract class PlatformPropsImpl {
      *   <li>linux-aarch64</li>
      *   <li>linux-amd64</li>
      *   <li>linux-ppc64</li>
+     *   <li>linux-ppc64le</li>
      *   <li>linux-mips64</li>
      *   <li>linux-ia64</li>
      *   <li>linux-sparcv9</li>
@@ -578,7 +579,7 @@ public abstract class PlatformPropsImpl {
                 _and_arch_tmp = "amd64";
                 break;
             case PPC64:
-                _and_arch_tmp = "ppc64";
+                _and_arch_tmp = littleEndian ? "ppc64le" : "ppc64";
                 break;
             case MIPS_64:
                 _and_arch_tmp = "mips64";


### PR DESCRIPTION
This patch was tested on a Debian ppc64el porter box where I observed
similar test case failures than on amd64. See bugzilla ticket #1246.