### PR TITLE
Bug 682: Rename com.sun.gluegen -> com.jogamp.gluegen in doc/**

### DIFF
--- a/doc/HowToBuild.html
+++ b/doc/HowToBuild.html
@@ -237,7 +237,7 @@ apt-get install lib32z1 lib32ncurses5 lib32bz2-1.0 gcc-multilib lib32gcc1 lib32g
                         </li>
 
                         <li>
-                            <b>CharScanner; panic: ClassNotFoundException: com.sun.gluegen.cgram.CToken</b>
+                            <b>CharScanner; panic: ClassNotFoundException: com.jogamp.gluegen.cgram.CToken</b>
 
                             This occurs because ANTLR was dropped into the Extensions
                             directory of the JRE/JDK. On Windows and Linux, delete any ANTLR jars from jre/lib/ext,

--- a/doc/manual/example1/gen.sh
+++ b/doc/manual/example1/gen.sh
@@ -14,5 +14,5 @@ else
   SEP=:
 fi
 
-echo java -cp $GLUEGEN_JAR$SEP$ANTLR_JAR com.sun.gluegen.GlueGen -I. -Ecom.sun.gluegen.JavaEmitter -Cfunction.cfg function.h
-java -cp $GLUEGEN_JAR$SEP$ANTLR_JAR com.sun.gluegen.GlueGen -I. -Ecom.sun.gluegen.JavaEmitter -Cfunction.cfg function.h
+echo java -cp $GLUEGEN_JAR$SEP$ANTLR_JAR com.jogamp.gluegen.GlueGen -I. -Ecom.jogamp.gluegen.JavaEmitter -Cfunction.cfg function.h
+java -cp $GLUEGEN_JAR$SEP$ANTLR_JAR com.jogamp.gluegen.GlueGen -I. -Ecom.jogamp.gluegen.JavaEmitter -Cfunction.cfg function.h

--- a/doc/manual/example2/gen.sh
+++ b/doc/manual/example2/gen.sh
@@ -14,4 +14,4 @@ else
   SEP=:
 fi
 
-java -cp $GLUEGEN_JAR$SEP$ANTLR_JAR com.sun.gluegen.GlueGen -I. -Ecom.sun.gluegen.JavaEmitter -Cfunction.cfg function.h
+java -cp $GLUEGEN_JAR$SEP$ANTLR_JAR com.jogamp.gluegen.GlueGen -I. -Ecom.jogamp.gluegen.JavaEmitter -Cfunction.cfg function.h

--- a/doc/manual/example3/gen.sh
+++ b/doc/manual/example3/gen.sh
@@ -14,4 +14,4 @@ else
   SEP=:
 fi
 
-java -cp $GLUEGEN_JAR$SEP$ANTLR_JAR com.sun.gluegen.GlueGen -I. -Ecom.sun.gluegen.JavaEmitter -Cfunction.cfg function.h
+java -cp $GLUEGEN_JAR$SEP$ANTLR_JAR com.jogamp.gluegen.GlueGen -I. -Ecom.jogamp.gluegen.JavaEmitter -Cfunction.cfg function.h

--- a/doc/manual/example4/gen.sh
+++ b/doc/manual/example4/gen.sh
@@ -14,4 +14,4 @@ else
   SEP=:
 fi
 
-java -cp $GLUEGEN_JAR$SEP$ANTLR_JAR com.sun.gluegen.GlueGen -I. -Ecom.sun.gluegen.JavaEmitter -Cfunction.cfg function.h
+java -cp $GLUEGEN_JAR$SEP$ANTLR_JAR com.jogamp.gluegen.GlueGen -I. -Ecom.jogamp.gluegen.JavaEmitter -Cfunction.cfg function.h

--- a/doc/manual/example5/gen.sh
+++ b/doc/manual/example5/gen.sh
@@ -14,4 +14,4 @@ else
   SEP=:
 fi
 
-java -cp $GLUEGEN_JAR$SEP$ANTLR_JAR com.sun.gluegen.GlueGen -I. -Ecom.sun.gluegen.JavaEmitter -Cfunction.cfg function.h
+java -cp $GLUEGEN_JAR$SEP$ANTLR_JAR com.jogamp.gluegen.GlueGen -I. -Ecom.jogamp.gluegen.JavaEmitter -Cfunction.cfg function.h

--- a/doc/manual/example6/gen.sh
+++ b/doc/manual/example6/gen.sh
@@ -14,4 +14,4 @@ else
   SEP=:
 fi
 
-java -cp $GLUEGEN_JAR$SEP$ANTLR_JAR com.sun.gluegen.GlueGen -I. -Ecom.sun.gluegen.JavaEmitter -Cfunction.cfg function.h
+java -cp $GLUEGEN_JAR$SEP$ANTLR_JAR com.jogamp.gluegen.GlueGen -I. -Ecom.jogamp.gluegen.JavaEmitter -Cfunction.cfg function.h

--- a/doc/manual/example7/gen.sh
+++ b/doc/manual/example7/gen.sh
@@ -14,4 +14,4 @@ else
   SEP=:
 fi
 
-java -cp $GLUEGEN_JAR$SEP$ANTLR_JAR com.sun.gluegen.GlueGen -I. -Ecom.sun.gluegen.JavaEmitter -Cfunction.cfg function.h
+java -cp $GLUEGEN_JAR$SEP$ANTLR_JAR com.jogamp.gluegen.GlueGen -I. -Ecom.jogamp.gluegen.JavaEmitter -Cfunction.cfg function.h

--- a/doc/manual/index.html
+++ b/doc/manual/index.html
@@ -363,7 +363,7 @@
 
 
                     <dl>
-                        <dt> <strong>CharScanner; panic: ClassNotFoundException: com.sun.gluegen.cgram.CToken</strong></dt>
+                        <dt> <strong>CharScanner; panic: ClassNotFoundException: com.jogamp.gluegen.cgram.CToken</strong></dt>
                         <dd> This occurs because ANTLR was dropped into the Extensions
                             directory of the JRE/JDK. On Windows and Linux, delete any ANTLR
                             jars from jre/lib/ext, and on Mac OS X, delete them from
@@ -397,9 +397,9 @@
                             <em>emitterClassName</em> as the fully-qualified name of the
                             emitter class which will be used by GlueGen to generate the glue
                             code. The emitter class must implement the
-                            <code>com.sun.gluegen.GlueEmitter</code> interface. If this
+                            <code>com.jogamp.gluegen.GlueEmitter</code> interface. If this
                             option is not specified, a
-                            <code>com.sun.gluegen.JavaEmitter</code> will be used by default.
+                            <code>com.jogamp.gluegen.JavaEmitter</code> will be used by default.
                         </li>
                         <li> -C<em>cfgFile</em> adds <em>cfgFile</em> to the list of
                             configuration files used to set up the chosen emitter. This is
@@ -435,7 +435,7 @@
 
                     <pre>
 &lt;taskdef name="gluegen"
-    classname="com.sun.gluegen.ant.GlueGenTask"
+    classname="com.jogamp.gluegen.ant.GlueGenTask"
     classpathref="gluegen.classpath" /&gt;
                     </pre>
 
@@ -445,7 +445,7 @@
 &lt;gluegen src="[header to parse]" 
          config="[configuration file]"
          includeRefid="[dirset for include path]"
-         emitter="com.sun.gluegen.JavaEmitter"&gt;
+         emitter="com.jogamp.gluegen.JavaEmitter"&gt;
     &lt;classpath refid="gluegen.classpath" /&gt;
 &lt;/gluegen&gt;
                     </pre>
@@ -1679,8 +1679,8 @@
                     </p>
 
                     <pre>
-    java -cp gluegen.jar:antlr.jar com.sun.gluegen.GlueGen \
-        -I. -Ecom.sun.gluegen.JavaEmitter -Cfunction.cfg function.h
+    java -cp gluegen.jar:antlr.jar com.jogamp.gluegen.GlueGen \
+        -I. -Ecom.jogamp.gluegen.JavaEmitter -Cfunction.cfg function.h
                     </pre>
 
                     <p> The resulting Java and native code needs to be compiled, and the


### PR DESCRIPTION
This is something that should have been part of the 6f2d046c8d532db94f6af5003e341104d5bf4aff changeset back in 2010.

I use Bug 682 because I consider renaming com.sun.\* to  com.jogamp.\* to be part of the Bug 682 scoop to stay out of using name-spaces that are prohibited to be extend according to the Java SE binary license section F. JAVA TECHNOLOGY RESTRICTIONS.
http://www.oracle.com/technetwork/java/javase/terms/license/index.html

https://jogamp.org/bugzilla/show_bug.cgi?id=682
