### PR TITLE
Add AArch64/Linux definitions from Fedora

### DIFF
--- a/make/build.xml
+++ b/make/build.xml
@@ -264,6 +264,12 @@
       <property name="linker.cfg.id"                        value="linker.cfg.linux.amd64" />
     </target>
     
+    <target name="declare.linux.aarch64" if="isLinuxARM64">
+      <echo message="Linux.AArch64" />
+      <property name="compiler.cfg.id"                      value="compiler.cfg.linux.aarch64" />
+      <property name="linker.cfg.id"                        value="linker.cfg.linux.aarch64" />
+    </target>
+
     <target name="declare.linux.ia64" if="isLinuxIA64">
       <echo message="Linux.IA64" />
       <property name="compiler.cfg.id"                      value="compiler.cfg.linux" /> 
@@ -324,7 +330,7 @@
       <property name="linker.cfg.id"                        value="linker.cfg.linux.sparc" /> 
     </target>
     
-    <target name="declare.linux" depends="declare.linux.x86,declare.linux.amd64,declare.linux.ia64,declare.linux.hppa,declare.linux.mips,declare.linux.mipsel,declare.linux.ppc,declare.linux.s390,declare.linux.s390x,declare.linux.sparc,declare.linux.armv6" if="isLinux" >
+    <target name="declare.linux" depends="declare.linux.x86,declare.linux.amd64,declare.linux.ia64,declare.linux.hppa,declare.linux.mips,declare.linux.mipsel,declare.linux.ppc,declare.linux.s390,declare.linux.s390x,declare.linux.sparc,declare.linux.armv6,declare.linux.aarch64" if="isLinux" >
       <property name="c.src.dir.os"                         value="unix" />
     </target>
 

--- a/make/gluegen-cpptasks-base.xml
+++ b/make/gluegen-cpptasks-base.xml
@@ -457,6 +457,9 @@
         <istrue value="${isAMD64}" />
       </and>
     </condition>
+    <condition property="isAArch64">
+      <os arch="aarch64" />
+    </condition>
     <condition property="isLinuxIA64">
       <and>
         <istrue value="${isLinux}" />
@@ -1467,7 +1470,7 @@
       <echo message="Linux.aarch64" />
       <property name="compiler.cfg.id.base"          value="compiler.cfg.linux.aarch64" /> 
       <property name="linker.cfg.id.base"            value="linker.cfg.linux.aarch64" /> 
-      <property name="java.lib.dir.platform"         value="${java.home.dir}/jre/lib/arm" />
+      <property name="java.lib.dir.platform"         value="${java.home.dir}/jre/lib/aarch64" />
     </target>
 
     <target name="gluegen.cpptasks.declare.compiler.linux.ia64" if="isLinuxIA64">


### PR DESCRIPTION
Those changes were required to get gluegen2 2.3.2 built properly under Fedora for AArch64 architecture.

jogl2 and scilab built with own patches and scilab was running (checked with 'plot3d' command).

Signed-off-by: Marcin Juszkiewicz mjuszkiewicz@redhat.com
