### PR TITLE
Use system property to detect Android

### DIFF
--- a/src/java/com/jogamp/common/os/AndroidVersion.java
+++ b/src/java/com/jogamp/common/os/AndroidVersion.java
@@ -74,15 +74,20 @@ public class AndroidVersion {
         Object abvObject= null;
         Class<?> abvcClass = null;
         Object abvcObject= null;
-        try {
-            abClass = ReflectionUtil.getClass(androidBuild, true, cl);
-            abObject = abClass.newInstance();
-            abvClass = ReflectionUtil.getClass(androidBuildVersion, true, cl);
-            abvObject = abvClass.newInstance();
-            abvcClass = ReflectionUtil.getClass(androidBuildVersionCodes, true, cl);
-            abvcObject = abvcClass.newInstance();
-        } catch (final Exception e) { /* n/a */ }
-        isAvailable = null != abObject && null != abvObject;
+
+        boolean isDalvikVm = "Dalvik".equals(System.getProperty("java.vm.name"));
+
+        if (isDalvikVm) {
+          try {
+              abClass = ReflectionUtil.getClass(androidBuild, true, cl);
+              abObject = abClass.newInstance();
+              abvClass = ReflectionUtil.getClass(androidBuildVersion, true, cl);
+              abvObject = abvClass.newInstance();
+              abvcClass = ReflectionUtil.getClass(androidBuildVersionCodes, true, cl);
+              abvcObject = abvcClass.newInstance();
+          } catch (final Exception e) { /* n/a */ }
+        }
+        isAvailable = isDalvikVm && null != abObject && null != abvObject;
         if(isAvailable) {
             CPU_ABI = getString(abClass, abObject, "CPU_ABI", true);
             CPU_ABI2 = getString(abClass, abObject, "CPU_ABI2", true);


### PR DESCRIPTION
This adds the use of the java.vm.version system property to check when the library is running on an Android system.
Reported as https://jogamp.org/bugzilla/show_bug.cgi?id=1300
