### PR TITLE
Fix casting in Buffers.c

### DIFF
--- a/src/native/common/Buffers.c
+++ b/src/native/common/Buffers.c
@@ -25,6 +25,6 @@ Java_com_jogamp_common_nio_Buffers_strnlenImpl(JNIEnv *env, jclass _unused, jlon
 
 JNIEXPORT jlong JNICALL 
 Java_com_jogamp_common_nio_Buffers_memcpyImpl(JNIEnv *env, jclass _unused, jlong jdest, jlong jsrc, jlong jlen) {
-    return ( 0 != jdest && 0 != jsrc && 0 < jlen ) ? memcpy((void *)(intptr_t)jdest, (void *)(intptr_t)jsrc, (size_t)jlen) : jdest;
+    return ( 0 != jdest && 0 != jsrc && 0 < jlen ) ? (jlong) (intptr_t) memcpy((void *)(intptr_t)jdest, (void *)(intptr_t)jsrc, (size_t)jlen) : jdest;
 }
 


### PR DESCRIPTION
When first trying to build from the latest master branch, I got this error:
```
gluegen.build.c.impl:
     [echo] clearing gluegen.build.shasum.done (2) - was ${gluegen.build.shasum.done}
     [echo] Output lib name = gluegen_rt -> libgluegen_rt.dylib [shared]
    [mkdir] Created dir: /Users/SiboVanGool/Desktop/Sibo/Projects/OpenRocket/Software/jogamp-SiboVG/gluegen/build/obj
     [echo] Compiling src/native/unix/*.c src/native/common/*.c
     [echo] user.dir=/Users/SiboVanGool/Desktop/Sibo/Projects/OpenRocket/Software/jogamp-SiboVG/gluegen/make
       [cc] 7 total files to be compiled.
       [cc] /Users/SiboVanGool/Desktop/Sibo/Projects/OpenRocket/Software/jogamp-SiboVG/gluegen/src/native/common/Buffers.c:28:52: warning: pointer/integer type mismatch in conditional expression ('void *' and 'jlong' (aka 'long long')) [-Wconditional-type-mismatch]
       [cc]     return ( 0 != jdest && 0 != jsrc && 0 < jlen ) ? memcpy((void *)(intptr_t)jdest, (void *)(intptr_t)jsrc, (size_t)jlen) : jdest;
       [cc]                                                    ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   ~~~~~
       [cc] /Users/SiboVanGool/Desktop/Sibo/Projects/OpenRocket/Software/jogamp-SiboVG/gluegen/src/native/common/Buffers.c:28:12: error: incompatible pointer to integer conversion returning 'void *' from a function with result type 'jlong' (aka 'long long') [-Wint-conversion]
       [cc]     return ( 0 != jdest && 0 != jsrc && 0 < jlen ) ? memcpy((void *)(intptr_t)jdest, (void *)(intptr_t)jsrc, (size_t)jlen) : jdest;
       [cc]            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       [cc] 1 warning and 1 error generated.
```

The issue was a mismatch in the `Java_com_jogamp_common_nio_Buffers_memcpyImpl` function. Specifically, the return type of the function is `jlong`, but the conditional expression returns either the result of `memcpy` (which is a `void*`) or `jdest` (which is a `jlong`). To resolve this, I cast the return value of `memcpy` to `jlong`.